### PR TITLE
Endpoint config improvements

### DIFF
--- a/.github/actions/integration-tests/action.yaml
+++ b/.github/actions/integration-tests/action.yaml
@@ -22,7 +22,7 @@ runs:
       shell: bash
       run: |
         python -m pip install --upgrade pip
-        pip install -r python/requirements.txt
+        pip install -r requirements.txt
         pip install pytest
 
     - name: Run integration tests

--- a/anaconda_opentelemetry/config.py
+++ b/anaconda_opentelemetry/config.py
@@ -21,7 +21,7 @@ It validates the format of endpoints and ensures they conform to the expected st
 
 
 def deprecated(func):
-    """This is a decorator to mark functions as deprecated."""
+    # This is a decorator to mark functions as deprecated.
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         warnings.warn(

--- a/anaconda_opentelemetry/signals.py
+++ b/anaconda_opentelemetry/signals.py
@@ -150,7 +150,7 @@ class _AnacondaLogger(_AnacondaCommon):
         return levels.get(str_level.lower(), logging.DEBUG)
 
     def _test_set_console_mock(self, new_out):  # For testing only...
-        if self._console_exporter is not None:
+        if self._console_exporter is not None and new_out is not None:
             saved = self._console_exporter.out
             self._console_exporter.out = new_out
             return saved

--- a/anaconda_opentelemetry/signals.py
+++ b/anaconda_opentelemetry/signals.py
@@ -105,11 +105,12 @@ class _AnacondaLogger(_AnacondaCommon):
         self.logger_endpoint = config._get_logging_endpoint()
 
         # Create logger provider
-        provider = LoggerProvider(resource=self.resource)
-
+        self._provider = LoggerProvider(resource=self.resource)
+        self._console_exporter: ConsoleLogExporter | None = None
         # Add OTLP exporter
         if self.use_console_exporters:
             exporter = ConsoleLogExporter()
+            self._console_exporter = exporter
         else:
             auth_token = config._get_auth_token_logging()
             headers: Dict[str, str] = {}
@@ -128,15 +129,11 @@ class _AnacondaLogger(_AnacondaCommon):
                                         certificate_file=config._get_ca_cert_logging(),
                                         headers=headers)
         self._exporter = exporter
-        provider.add_log_record_processor(
-            BatchLogRecordProcessor(
-                exporter
-            )
-        )
-        self._handler = LoggingHandler(level=self.log_level, logger_provider=provider)
+        self._processor = BatchLogRecordProcessor(self._exporter)
+        self._provider.add_log_record_processor(self._processor)
+        self._handler = LoggingHandler(level=self.log_level, logger_provider=self._provider)
 
     def tear_down(self):
-        # TODO: flush and shutdown
         _AnacondaLogger._instance = None
 
     def _get_log_level(self, str_level: str)-> int:
@@ -152,6 +149,12 @@ class _AnacondaLogger(_AnacondaCommon):
         }
         return levels.get(str_level.lower(), logging.DEBUG)
 
+    def _test_set_console_mock(self, new_out):  # For testing only...
+        if self._console_exporter is not None:
+            saved = self._console_exporter.out
+            self._console_exporter.out = new_out
+            return saved
+        return None
 
 class _AnacondaMetrics(_AnacondaCommon):
     # Singleton instance (internal only); provide a single instance of the metrics class

--- a/tests/unit_tests/config_test.py
+++ b/tests/unit_tests/config_test.py
@@ -15,7 +15,7 @@ class TestConfiguration:
         without={}
         has={Config.DEFAULT_ENDPOINT_NAME: 'grpc://localhost:4318'}
 
-        config1 = Config(default_endpoint='https://localhost:4317', config_dict=has)
+        config1 = Config(default_endpoint='https://localhost:4317', default_auth_token="SomeAuthToken", default_private_ca_cert_file='/tmp/cert', config_dict=has)
         assert 'https://localhost:4317' == config1._get_default_endpoint()
         config2 = Config(config_dict=has)
         assert 'grpc://localhost:4318' == config2._get_default_endpoint()
@@ -66,9 +66,9 @@ class TestConfiguration:
             Config(default_endpoint="http://127.0.0.255:1812")  # last quad cannot be ==255.
 
         cfg = Config(default_endpoint="http://localhost:2345")
-        cfg.set_logging_endpoint('http://localhost:2346')
-        cfg.set_metrics_endpoint('http://localhost:2347')
-        cfg.set_tracing_endpoint('http://localhost:2348')
+        cfg.set_logging_endpoint('http://localhost:2346', auth_token='', cert_ca_file='')
+        cfg.set_metrics_endpoint('http://localhost:2347', auth_token='', cert_ca_file='')
+        cfg.set_tracing_endpoint('http://localhost:2348', auth_token='', cert_ca_file='')
 
         with pytest.raises(ValueError):
             cfg.set_logging_endpoint('http://localhost:80000')

--- a/tests/unit_tests/test_files/example_app.py
+++ b/tests/unit_tests/test_files/example_app.py
@@ -130,9 +130,6 @@ def simulate_metric() -> str:
     return mock_out.getvalue()
 
 def simulate_log() -> str:
-    from opentelemetry.sdk._logs import LoggingHandler
-    from opentelemetry.sdk._logs.export import ConsoleLogExporter, BatchLogRecordProcessor
-
     # Create ExampleApp with logging enabled
     example = ExampleApp(use_console_exporter=True)
 

--- a/tests/unit_tests/test_files/example_app.py
+++ b/tests/unit_tests/test_files/example_app.py
@@ -147,9 +147,12 @@ def simulate_log() -> str:
 
     # Force flush logs to ensure they're written to our StringIO
     inst._provider.force_flush()
-    if saved is not None:
-        inst._test_set_console_mock(saved)
+
+    # Restore logger state
+    inst._test_set_console_mock(saved)
     example.remove_handler()
+
+    # return outout as a string
     return mock_out.getvalue()
 
 def simulate_trace() -> str:

--- a/tests/unit_tests/test_files/example_app.py
+++ b/tests/unit_tests/test_files/example_app.py
@@ -16,7 +16,8 @@ from anaconda_opentelemetry.signals import (
     record_histogram,
     increment_counter,
     get_trace,
-    _is_first_time
+    _is_first_time,
+    _AnacondaLogger
 )
 
 # Configure logging
@@ -56,11 +57,11 @@ class ExampleApp:
             initialize_telemetry(config, attrs, signal_types=["logging", "tracing", "metrics"])
         else:
             re_initialize_telemetry(attrs)
+        # inject logger
+        logger.addHandler(get_telemetry_logger_handler())
 
-        if first_time:
-            # inject logger
-            log = logging.getLogger()
-            log.addHandler(get_telemetry_logger_handler())
+    def remove_handler(self):
+        logger.removeHandler(get_telemetry_logger_handler())
 
     def export_log(self) -> None:
         """Simulate a user request with various telemetry signals."""
@@ -137,48 +138,18 @@ def simulate_log() -> str:
 
     # Create a StringIO object to capture output
     mock_out = StringIO()
-    exporter_found = False
-
-    # Get the root logger
-    root_logger = logging.getLogger()
 
     # Find the LoggingHandler
-    for handler in root_logger.handlers:
-        if isinstance(handler, LoggingHandler):
-            # Access the logger provider
-            logger_provider = handler._logger_provider
-            # The logger provider should have _multi_log_record_processor list
-            if hasattr(logger_provider, '_multi_log_record_processor'):
-                # Iterate through the log record processors
-                processors = logger_provider._multi_log_record_processor._log_record_processors
-                for processor in processors:
-                    if isinstance(processor, BatchLogRecordProcessor):
-                        # Access the exporter through the processor
-                        if hasattr(processor, '_exporter'):
-                            exporter = processor._exporter
-                            if isinstance(exporter, ConsoleLogExporter):
-                                # Replace its out attribute
-                                exporter.out = mock_out
-                                exporter_found = True
-                                break
+    inst: _AnacondaLogger = _AnacondaLogger._instance
+    saved = inst._test_set_console_mock(mock_out)
 
-            if exporter_found:
-                break
-
-    if not exporter_found:
-        raise RuntimeError("ConsoleLogExporter not found in log record processors")
-
-    # Send a log to stdout
     example.export_log()
 
     # Force flush logs to ensure they're written to our StringIO
-    for handler in root_logger.handlers:
-        if isinstance(handler, LoggingHandler):
-            logger_provider = handler._logger_provider
-            if hasattr(logger_provider, 'force_flush'):
-                logger_provider.force_flush()
-            break
-
+    inst._provider.force_flush()
+    if saved is not None:
+        inst._test_set_console_mock(saved)
+    example.remove_handler()
     return mock_out.getvalue()
 
 def simulate_trace() -> str:


### PR DESCRIPTION
Logger still causes "write on closed handle" type errors, but this does not affect the test results.

We should revisit the Logger integration in Python, I would argue its not needed and should be removed.