### PR TITLE
pip install reads version

### DIFF
--- a/anaconda_opentelemetry/__version__.py
+++ b/anaconda_opentelemetry/__version__.py
@@ -4,6 +4,6 @@
 
 # __version__.py
 
-# DO NOT Change the __SDK_VERSION__ line!!! MUST be "0.0.0.devbuild"!!
+# DO NOT edit manually — updated by the update-sdk-version GitHub Actions workflow.
 __SDK_VERSION__ = "1.1.0"
 __TELEMETRY_SCHEMA_VERSION__ = "0.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ dependencies = [
 
 requires-python = ">=3.9"
 
+[tool.setuptools.dynamic]
+version = {attr = "anaconda_opentelemetry.__version__.__SDK_VERSION__"}
+
 [tool.setuptools.packages.find]
 include = ["anaconda_opentelemetry"]
 


### PR DESCRIPTION
The version is correctly available at `anaconda_opentelemetry.__version__.__SDK_VERSION__`, which is created through github actions. But the pyproject.toml was not instructed to look for the version there. This would lead to pip installs not being aware of the version number. Also, I've updated the comment in `__version__.py` to state where the value comes from.