### PR TITLE
allow consumers to manage shutdown

### DIFF
--- a/anaconda_opentelemetry/__init__.py
+++ b/anaconda_opentelemetry/__init__.py
@@ -11,6 +11,8 @@ from .signals import record_histogram as record_histogram
 from .signals import increment_counter as increment_counter
 from .signals import decrement_counter as decrement_counter
 from .signals import get_trace as get_trace
+from .signals import shutdown_telemetry as shutdown_telemetry
+from .signals import flush_telemetry as flush_telemetry
 from .signals import ASpan
 from .config import Configuration
 from .attributes import ResourceAttributes

--- a/anaconda_opentelemetry/__version__.py
+++ b/anaconda_opentelemetry/__version__.py
@@ -5,5 +5,5 @@
 # __version__.py
 
 # DO NOT edit manually — updated by the update-sdk-version GitHub Actions workflow.
-__SDK_VERSION__ = "1.1.0"
+__SDK_VERSION__ = "1.2.0"
 __TELEMETRY_SCHEMA_VERSION__ = "0.4.0"

--- a/anaconda_opentelemetry/common.py
+++ b/anaconda_opentelemetry/common.py
@@ -44,6 +44,8 @@ class _AnacondaCommon:
         self.default_endpoint = config._get_default_endpoint()
         # export options
         self.use_console_exporters = config._get_console_exporter()
+        # shutdown on exit flag
+        self._shutdown_on_exit = config._get_shutdown_on_exit()
 
     def make_otel_resource(self, attributes: Attributes):
         # Read resource attributes

--- a/anaconda_opentelemetry/config.py
+++ b/anaconda_opentelemetry/config.py
@@ -56,6 +56,7 @@ class Configuration:
     - SKIP_INTERNET_CHECK_NAME - If you are running in an environment that does not have access to the internet, set this to True.
     - USE_CUMULATIVE_METRICS_NAME - If aggregating data in the client is required for Counter, or Histogram set this to a True state.
     - PROXY_URL_NAME - Used to set the proxy for telemetry exporters in this package
+    - SHUTDOWN_ON_EXIT_NAME - If True (default), providers register atexit handlers that flush on interpreter exit. If False, the caller must manually call shutdown_telemetry() or flush_telemetry() before the process exits.
 
     To initializes the Configuration instance.
 
@@ -87,6 +88,7 @@ class Configuration:
     SKIP_INTERNET_CHECK_NAME        = 'skip_internet_check'
     USE_CUMULATIVE_METRICS_NAME     = 'use_cumulative_metrics'
     PROXY_URL_NAME                  = 'proxy_url'
+    SHUTDOWN_ON_EXIT_NAME           = 'shutdown_on_exit'
 
     _base_names: List[str] = [
         DEFAULT_ENDPOINT_NAME,
@@ -109,6 +111,7 @@ class Configuration:
         SKIP_INTERNET_CHECK_NAME,
         USE_CUMULATIVE_METRICS_NAME,
         PROXY_URL_NAME,
+        SHUTDOWN_ON_EXIT_NAME,
     ]
 
     _endpoint_names: List[str] = [
@@ -136,6 +139,7 @@ class Configuration:
         USE_CONSOLE_EXPORTER_NAME,
         SKIP_INTERNET_CHECK_NAME,
         USE_CUMULATIVE_METRICS_NAME,
+        SHUTDOWN_ON_EXIT_NAME,
     ]
 
     _int_value_names: List[str] = [
@@ -567,6 +571,23 @@ class Configuration:
         self._config[self.PROXY_URL_NAME] = proxy_url
         return self
 
+    def set_shutdown_on_exit(self, value: bool):
+        """
+        Sets whether providers register atexit handlers that flush on interpreter exit.
+        If True (default), each provider registers an ``atexit`` handler that flushes on interpreter exit.
+        If False, no atexit handlers are registered and the caller becomes responsible for flushing:
+        call ``shutdown_telemetry()`` (or ``flush_telemetry()``) before the process exits, otherwise
+        buffered telemetry is silently dropped.The environment variable is 'ATEL_SHUTDOWN_ON_EXIT'.
+
+        Args:
+            value (bool): True to register atexit handlers, False to manage shutdown manually.
+
+        Returns:
+            Self
+        """
+        self._config[self.SHUTDOWN_ON_EXIT_NAME] = value
+        return self
+
     def _get_proxy_url(self) -> str:
         return self._config.get(self.PROXY_URL_NAME, None)
 
@@ -786,3 +807,6 @@ class Configuration:
 
     def _get_use_cumulative_metrics(self) -> bool:
         return self._config.get(self.USE_CUMULATIVE_METRICS_NAME, False)
+
+    def _get_shutdown_on_exit(self) -> bool:
+        return self._config.get(self.SHUTDOWN_ON_EXIT_NAME, True)

--- a/anaconda_opentelemetry/logging.py
+++ b/anaconda_opentelemetry/logging.py
@@ -19,6 +19,7 @@ import json
 import logging
 from typing import Dict
 
+from opentelemetry import _logs
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler, LogRecord
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, ConsoleLogExporter
 
@@ -63,13 +64,17 @@ class _AnacondaLogger(_AnacondaCommon):
 
     _default_log_attributes = {log_event_name_key: "__LOG__"}
 
-    def __init__(self, config: Config, attributes: Attributes):
+    def __init__(self, config: Config, attributes: Attributes, shutdown_on_exit: bool = True):
         super().__init__(config, attributes)
         self.log_level = self._get_log_level(config._get_logging_level())
         self.logger_endpoint = config._get_logging_endpoint()
 
         # Create logger provider
-        self._provider = LoggerProvider(resource=self.resource)
+        self._provider = LoggerProvider(resource=self.resource, shutdown_on_exit=shutdown_on_exit)
+        try:
+            _logs.set_logger_provider(self._provider)
+        except Exception:
+            self.logger.warning("The logger provider was previously set; this call is ignored.")
         self._console_exporter: ConsoleLogExporter | None = None
         # Add OTLP exporter
         if self.use_console_exporters:

--- a/anaconda_opentelemetry/logging.py
+++ b/anaconda_opentelemetry/logging.py
@@ -64,13 +64,13 @@ class _AnacondaLogger(_AnacondaCommon):
 
     _default_log_attributes = {log_event_name_key: "__LOG__"}
 
-    def __init__(self, config: Config, attributes: Attributes, shutdown_on_exit: bool = True):
+    def __init__(self, config: Config, attributes: Attributes):
         super().__init__(config, attributes)
         self.log_level = self._get_log_level(config._get_logging_level())
         self.logger_endpoint = config._get_logging_endpoint()
 
         # Create logger provider
-        self._provider = LoggerProvider(resource=self.resource, shutdown_on_exit=shutdown_on_exit)
+        self._provider = LoggerProvider(resource=self.resource, shutdown_on_exit=self._shutdown_on_exit)
         try:
             _logs.set_logger_provider(self._provider)
         except Exception:

--- a/anaconda_opentelemetry/metrics.py
+++ b/anaconda_opentelemetry/metrics.py
@@ -46,7 +46,7 @@ class _AnacondaMetrics(_AnacondaCommon):
         True: "CUMULATIVE"
     }
 
-    def __init__(self, config: Config, attributes: Attributes, shutdown_on_exit: bool = True):
+    def __init__(self, config: Config, attributes: Attributes):
         super().__init__(config, attributes)
 
         self.metrics_endpoint = config._get_metrics_endpoint()
@@ -55,7 +55,6 @@ class _AnacondaMetrics(_AnacondaCommon):
         self.up_down_counter_objects: Dict[str, Any] = {}
         self.histogram_objects: Dict[str, Any] = {}
 
-        self._shutdown_on_exit = shutdown_on_exit
         self.meter = self._setup_metrics(config)
         self.create_dispatcher = {
             'simple_counter': self.meter.create_counter,

--- a/anaconda_opentelemetry/metrics.py
+++ b/anaconda_opentelemetry/metrics.py
@@ -46,7 +46,7 @@ class _AnacondaMetrics(_AnacondaCommon):
         True: "CUMULATIVE"
     }
 
-    def __init__(self, config: Config, attributes: Attributes):
+    def __init__(self, config: Config, attributes: Attributes, shutdown_on_exit: bool = True):
         super().__init__(config, attributes)
 
         self.metrics_endpoint = config._get_metrics_endpoint()
@@ -55,6 +55,7 @@ class _AnacondaMetrics(_AnacondaCommon):
         self.up_down_counter_objects: Dict[str, Any] = {}
         self.histogram_objects: Dict[str, Any] = {}
 
+        self._shutdown_on_exit = shutdown_on_exit
         self.meter = self._setup_metrics(config)
         self.create_dispatcher = {
             'simple_counter': self.meter.create_counter,
@@ -102,8 +103,10 @@ class _AnacondaMetrics(_AnacondaCommon):
         # Create and set meter provider
         meter_provider = MeterProvider(
             resource=self.resource,
-            metric_readers=[self.metric_reader]
+            metric_readers=[self.metric_reader],
+            shutdown_on_exit=self._shutdown_on_exit
         )
+        self._provider = meter_provider
         try:
             metrics.set_meter_provider(meter_provider)
         except Exception as e:

--- a/anaconda_opentelemetry/signals.py
+++ b/anaconda_opentelemetry/signals.py
@@ -11,11 +11,14 @@ signals) using OpenTelemetry. It includes classes for handling logging, metrics,
 tracing, as well as functions for initializing the telemetry system and recording metrics.
 """
 
-import logging, socket
+import logging, socket, threading
 from typing import Dict, Iterator, List
 from contextlib import contextmanager
 
-from opentelemetry.sdk._logs import LoggingHandler
+from opentelemetry import trace, metrics, _logs
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk._logs import LoggingHandler, LoggerProvider
 
 from .config import Configuration as Config
 from .attributes import ResourceAttributes as Attributes
@@ -59,7 +62,8 @@ __CONFIG = None
 # Exposed APIs
 def initialize_telemetry(config: Config,
                          attributes: Attributes = None,
-                         signal_types: List[str] = ['metrics']):  # Follows what the backend has implemented.
+                         signal_types: List[str] = ['metrics'],
+                         shutdown_on_exit: bool = True):  # Follows what the backend has implemented.
     """
     Initializes the telemetry system.
 
@@ -72,6 +76,11 @@ def initialize_telemetry(config: Config,
             it will override any values shared with configuration file.
         signal_types (list, optional): List of metric types to initialize. Defaults to ['logging','metrics','tracing'].
             Supported values are 'logging', 'metrics', and 'tracing'. If an empty list is provided, no metrics will be initialized.
+        shutdown_on_exit (bool, optional): If True (default), each provider registers an
+            ``atexit`` handler that flushes on interpreter exit. If False, no atexit
+            handlers are registered and the caller becomes responsible for flushing:
+            call ``shutdown_telemetry()`` (or ``flush_telemetry()``) before the process
+            exits, otherwise buffered telemetry is silently dropped.
 
     Raises:
         ValueError: If the config passed is None or the attributes passed are None.
@@ -105,17 +114,17 @@ def initialize_telemetry(config: Config,
     # Initialize logging here...
     signal_type_count = 0
     if 'logging' in signal_types:
-        _AnacondaLogger._instance = _AnacondaLogger(*init_params)
+        _AnacondaLogger._instance = _AnacondaLogger(*init_params, shutdown_on_exit=shutdown_on_exit)
         signal_type_count += 1
 
     # Initialize the telemetry system here
     if 'metrics' in signal_types:
-        _AnacondaMetrics._instance = _AnacondaMetrics(*init_params)
+        _AnacondaMetrics._instance = _AnacondaMetrics(*init_params, shutdown_on_exit=shutdown_on_exit)
         signal_type_count += 1
 
     # Initialize tracing here...
     if 'tracing' in signal_types:
-        _AnacondaTrace._instance = _AnacondaTrace(*init_params)
+        _AnacondaTrace._instance = _AnacondaTrace(*init_params, shutdown_on_exit=shutdown_on_exit)
         signal_type_count += 1
 
     if signal_type_count == 0:
@@ -125,6 +134,99 @@ def initialize_telemetry(config: Config,
               "metric types in the parameter 'signal_types'."
         )
     __ANACONDA_TELEMETRY_INITIALIZED = True
+
+_SHUTDOWN_DONE = False
+_shutdown_lock = threading.Lock()
+
+
+def flush_telemetry() -> bool:
+    """Force-flush all initialized telemetry providers.
+
+    Uses the standard OTel global getters to retrieve providers.
+    Returns True if all providers flushed successfully.
+    """
+    if not __ANACONDA_TELEMETRY_INITIALIZED:
+        return False
+    success = True
+    try:
+        tp = trace.get_tracer_provider()
+        if isinstance(tp, TracerProvider):
+            try:
+                tp.force_flush()
+            except Exception:
+                logging.getLogger(__package__).debug("Tracer flush failed", exc_info=True)
+                success = False
+
+        mp = metrics.get_meter_provider()
+        if isinstance(mp, MeterProvider):
+            try:
+                mp.force_flush()
+            except Exception:
+                logging.getLogger(__package__).debug("Meter flush failed", exc_info=True)
+                success = False
+
+        lp = _logs.get_logger_provider()
+        if isinstance(lp, LoggerProvider):
+            try:
+                lp.force_flush()
+            except Exception:
+                logging.getLogger(__package__).debug("Logger flush failed", exc_info=True)
+                success = False
+    except Exception:
+        logging.getLogger(__package__).debug("flush_telemetry failed", exc_info=True)
+        success = False
+    return success
+
+
+def shutdown_telemetry(*, timeout_seconds: float | None = None) -> bool:
+    """Flush all telemetry providers at process shutdown, optionally time-bounded.
+
+    Performs a bounded *force-flush* (via :func:`flush_telemetry`). It intentionally does
+    not call ``provider.shutdown()``: at process exit that only adds worker-thread joins
+    (more blocking) with no benefit. Pair with
+    ``initialize_telemetry(..., shutdown_on_exit=False)`` to control flush timing from a
+    signal handler or atexit path.
+
+    With ``timeout_seconds=None`` the flush runs synchronously (unbounded). When set, the
+    flush runs on a daemon thread joined for at most ``timeout_seconds``; only the
+    caller's wait is bounded (a still-running flush thread is reaped at interpreter exit).
+
+    Idempotent and thread-safe: once a flush completes it is not repeated; concurrent or
+    re-entrant (signal-handler) calls never double-flush or block. A call that times out
+    does not mark completion, so a later call may retry.
+
+    The ``join`` blocks the calling thread, so do not call this with a ``timeout_seconds``
+    from inside an async event loop; use it from a signal handler, an atexit path, or a
+    dedicated thread.
+
+    Returns True if the flush completed (now or previously); False if telemetry was never
+    initialized, the flush timed out, or another call is already in progress.
+    """
+    global _SHUTDOWN_DONE
+    if not __ANACONDA_TELEMETRY_INITIALIZED:
+        return False
+    if _SHUTDOWN_DONE:
+        return True
+    # Non-blocking so a concurrent or re-entrant caller returns immediately instead of
+    # double-flushing or deadlocking (this may run inside a signal handler).
+    if not _shutdown_lock.acquire(blocking=False):
+        return _SHUTDOWN_DONE
+    try:
+        if _SHUTDOWN_DONE:
+            return True
+        if timeout_seconds is None:
+            completed = flush_telemetry()
+        else:
+            flush_thread = threading.Thread(target=flush_telemetry, daemon=True)
+            flush_thread.start()
+            flush_thread.join(timeout=timeout_seconds)
+            completed = not flush_thread.is_alive()
+        if completed:
+            _SHUTDOWN_DONE = True
+        return completed
+    finally:
+        _shutdown_lock.release()
+
 
 def change_signal_endpoint(signal_type: str,
                            new_endpoint: str,

--- a/anaconda_opentelemetry/signals.py
+++ b/anaconda_opentelemetry/signals.py
@@ -62,8 +62,7 @@ __CONFIG = None
 # Exposed APIs
 def initialize_telemetry(config: Config,
                          attributes: Attributes = None,
-                         signal_types: List[str] = ['metrics'],
-                         shutdown_on_exit: bool = True):  # Follows what the backend has implemented.
+                         signal_types: List[str] = ['metrics']):
     """
     Initializes the telemetry system.
 
@@ -76,11 +75,6 @@ def initialize_telemetry(config: Config,
             it will override any values shared with configuration file.
         signal_types (list, optional): List of metric types to initialize. Defaults to ['logging','metrics','tracing'].
             Supported values are 'logging', 'metrics', and 'tracing'. If an empty list is provided, no metrics will be initialized.
-        shutdown_on_exit (bool, optional): If True (default), each provider registers an
-            ``atexit`` handler that flushes on interpreter exit. If False, no atexit
-            handlers are registered and the caller becomes responsible for flushing:
-            call ``shutdown_telemetry()`` (or ``flush_telemetry()``) before the process
-            exits, otherwise buffered telemetry is silently dropped.
 
     Raises:
         ValueError: If the config passed is None or the attributes passed are None.
@@ -105,7 +99,7 @@ def initialize_telemetry(config: Config,
     elif type(attributes.parameters) != dict:
         raise ValueError(f"The parameters attribute in ResourceAttributes must be a dictionary")
 
-    # Right now, no acction is taken but it possible to disable telemetry with no access to the endpoint...
+    # Right now, no action is taken but it possible to disable telemetry with no access to the endpoint...
     _, _ = __check_internet_status(config, timeout=4)  # Max wait 4 seconds...
 
     # all params are the same currently so only write them once
@@ -114,17 +108,17 @@ def initialize_telemetry(config: Config,
     # Initialize logging here...
     signal_type_count = 0
     if 'logging' in signal_types:
-        _AnacondaLogger._instance = _AnacondaLogger(*init_params, shutdown_on_exit=shutdown_on_exit)
+        _AnacondaLogger._instance = _AnacondaLogger(*init_params)
         signal_type_count += 1
 
     # Initialize the telemetry system here
     if 'metrics' in signal_types:
-        _AnacondaMetrics._instance = _AnacondaMetrics(*init_params, shutdown_on_exit=shutdown_on_exit)
+        _AnacondaMetrics._instance = _AnacondaMetrics(*init_params)
         signal_type_count += 1
 
     # Initialize tracing here...
     if 'tracing' in signal_types:
-        _AnacondaTrace._instance = _AnacondaTrace(*init_params, shutdown_on_exit=shutdown_on_exit)
+        _AnacondaTrace._instance = _AnacondaTrace(*init_params)
         signal_type_count += 1
 
     if signal_type_count == 0:

--- a/anaconda_opentelemetry/signals.py
+++ b/anaconda_opentelemetry/signals.py
@@ -12,7 +12,7 @@ tracing, as well as functions for initializing the telemetry system and recordin
 """
 
 import logging, socket, threading
-from typing import Dict, Iterator, List
+from typing import Dict, Iterator, List, Optional
 from contextlib import contextmanager
 
 from opentelemetry import trace, metrics, _logs
@@ -178,7 +178,7 @@ def flush_telemetry() -> bool:
     return success
 
 
-def shutdown_telemetry(*, timeout_seconds: float | None = None) -> bool:
+def shutdown_telemetry(*, timeout_seconds: Optional[float] = None) -> bool:
     """Flush all telemetry providers at process shutdown, optionally time-bounded.
 
     Performs a bounded *force-flush* (via :func:`flush_telemetry`). It intentionally does

--- a/anaconda_opentelemetry/tracing.py
+++ b/anaconda_opentelemetry/tracing.py
@@ -112,17 +112,18 @@ class _AnacondaTrace(_AnacondaCommon):
     # Singleton instance (internal only); provide a single instance of the tracing class
     _instance = None
 
-    def __init__(self, config: Config, attributes: Attributes):
+    def __init__(self, config: Config, attributes: Attributes, shutdown_on_exit: bool = True):
         # Init singleton instance
         super().__init__(config, attributes)
         self.telemetry_export_interval_millis = config._get_tracing_export_interval_ms()
         self.tracing_endpoint = config._get_tracing_endpoint()
 
+        self._shutdown_on_exit = shutdown_on_exit
         self.tracer = self._setup_tracing(config)
 
     def _setup_tracing(self, config: Config) -> trace.Tracer:
         # Create tracer provider
-        tracer_provider = TracerProvider(resource=self.resource)
+        tracer_provider = TracerProvider(resource=self.resource, shutdown_on_exit=self._shutdown_on_exit)
 
         # Add OTLP exporter
         if self.use_console_exporters:
@@ -157,6 +158,7 @@ class _AnacondaTrace(_AnacondaCommon):
         )
 
         # Set as global provider
+        self._provider = tracer_provider
         try:
             trace.set_tracer_provider(tracer_provider)
         except Exception:

--- a/anaconda_opentelemetry/tracing.py
+++ b/anaconda_opentelemetry/tracing.py
@@ -112,13 +112,12 @@ class _AnacondaTrace(_AnacondaCommon):
     # Singleton instance (internal only); provide a single instance of the tracing class
     _instance = None
 
-    def __init__(self, config: Config, attributes: Attributes, shutdown_on_exit: bool = True):
+    def __init__(self, config: Config, attributes: Attributes):
         # Init singleton instance
         super().__init__(config, attributes)
         self.telemetry_export_interval_millis = config._get_tracing_export_interval_ms()
         self.tracing_endpoint = config._get_tracing_endpoint()
 
-        self._shutdown_on_exit = shutdown_on_exit
         self.tracer = self._setup_tracing(config)
 
     def _setup_tracing(self, config: Config) -> trace.Tracer:

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -111,11 +111,13 @@ def _provider_atexit_handlers():
 def test_shutdown_on_exit_false_skips_atexit_registration():
     from anaconda_opentelemetry.signals import initialize_telemetry
 
+    config = _make_config()
+    config.set_shutdown_on_exit(False)
+
     initialize_telemetry(
-        config=_make_config(),
+        config=config,
         attributes=_make_attributes(),
         signal_types=["logging", "metrics", "tracing"],
-        shutdown_on_exit=False,
     )
 
     handlers = _provider_atexit_handlers()
@@ -151,12 +153,13 @@ def test_global_logger_provider_retrievable_after_init():
     from opentelemetry import _logs
     from opentelemetry.sdk._logs import LoggerProvider
 
-    # shutdown_on_exit=False to avoid registering atexit handlers from this test
+    config = _make_config()
+    config.set_shutdown_on_exit(False)
+
     initialize_telemetry(
-        config=_make_config(),
+        config=config,
         attributes=_make_attributes(),
         signal_types=["logging", "metrics", "tracing"],
-        shutdown_on_exit=False,
     )
 
     lp = _logs.get_logger_provider()

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,0 +1,334 @@
+# SPDX-FileCopyrightText: 2025 Anaconda, Inc
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for shutdown_on_exit control, flush_telemetry, and shutdown_telemetry.
+
+These tests are intentionally self-contained: they do not contact a real OTel
+collector. Network is avoided via Configuration.set_skip_internet_check(True)
+and Configuration.set_console_exporter(True), and the bound/idempotency tests
+monkeypatch the in-module flush_telemetry to avoid touching OTel globals at
+all.
+"""
+
+import sys
+import time
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.append("./")
+
+
+# ---------------------------------------------------------------------------
+# Fixture: reset module-level singleton state between tests
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def reset_telemetry_state():
+    """Reset module-level singleton state between tests."""
+    import anaconda_opentelemetry.signals as sig
+    from anaconda_opentelemetry.logging import _AnacondaLogger
+    from anaconda_opentelemetry.metrics import _AnacondaMetrics
+    from anaconda_opentelemetry.tracing import _AnacondaTrace
+
+    # Defensive: undo any prior test's monkeypatch of these references
+    sig._AnacondaTrace = _AnacondaTrace
+    sig._AnacondaMetrics = _AnacondaMetrics
+    sig._AnacondaLogger = _AnacondaLogger
+
+    # Save original state
+    orig_init = sig.__ANACONDA_TELEMETRY_INITIALIZED
+    orig_shutdown = sig._SHUTDOWN_DONE
+    orig_logger = _AnacondaLogger._instance
+    orig_metrics = _AnacondaMetrics._instance
+    orig_trace = _AnacondaTrace._instance
+
+    # Reset to a clean baseline. __ANACONDA_TELEMETRY_INITIALIZED is a module-level
+    # global (not a class attribute), so Python name mangling does not apply here.
+    sig.__ANACONDA_TELEMETRY_INITIALIZED = False
+    sig._SHUTDOWN_DONE = False
+    _AnacondaLogger._instance = None
+    _AnacondaMetrics._instance = None
+    _AnacondaTrace._instance = None
+
+    yield
+
+    # Restore
+    sig.__ANACONDA_TELEMETRY_INITIALIZED = orig_init
+    sig._SHUTDOWN_DONE = orig_shutdown
+    _AnacondaLogger._instance = orig_logger
+    _AnacondaMetrics._instance = orig_metrics
+    _AnacondaTrace._instance = orig_trace
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _make_config():
+    """Build a Configuration that performs no real network I/O.
+
+    - set_skip_internet_check(True): skip DNS / endpoint reachability probes
+    - set_console_exporter(True): swap OTLP exporters for ConsoleExporter
+    """
+    from anaconda_opentelemetry.config import Configuration
+
+    config = Configuration(default_endpoint="http://localhost:4317")
+    config.set_skip_internet_check(True)
+    config.set_console_exporter(True)
+    return config
+
+
+def _make_attributes():
+    from anaconda_opentelemetry.attributes import ResourceAttributes
+
+    return ResourceAttributes("test_service", "1.0.0")
+
+
+def _provider_atexit_handlers():
+    """Return {provider_name: atexit_handler_or_None} for the three constructed singletons.
+
+    The SDK records the registered atexit handler on the provider instance, so this
+    reflects actual behavior regardless of how each SDK module imports ``atexit``
+    (``trace``/``_logs`` use ``atexit.register``; ``metrics`` uses ``from atexit import
+    register``, which ``patch("atexit.register")`` cannot observe). Note the SDK's own
+    attribute-name asymmetry: Tracer/Meter use ``_atexit_handler``; Logger uses
+    ``_at_exit_handler``.
+    """
+    from anaconda_opentelemetry.logging import _AnacondaLogger
+    from anaconda_opentelemetry.metrics import _AnacondaMetrics
+    from anaconda_opentelemetry.tracing import _AnacondaTrace
+
+    return {
+        "TracerProvider": getattr(_AnacondaTrace._instance._provider, "_atexit_handler", None),
+        "MeterProvider": getattr(_AnacondaMetrics._instance._provider, "_atexit_handler", None),
+        "LoggerProvider": getattr(_AnacondaLogger._instance._provider, "_at_exit_handler", None),
+    }
+
+
+# ---------------------------------------------------------------------------
+# (a) shutdown_on_exit=False -> no atexit registrations for any of the 3
+#     SDK *Provider classes
+# ---------------------------------------------------------------------------
+def test_shutdown_on_exit_false_skips_atexit_registration():
+    from anaconda_opentelemetry.signals import initialize_telemetry
+
+    initialize_telemetry(
+        config=_make_config(),
+        attributes=_make_attributes(),
+        signal_types=["logging", "metrics", "tracing"],
+        shutdown_on_exit=False,
+    )
+
+    handlers = _provider_atexit_handlers()
+    assert handlers["TracerProvider"] is None
+    assert handlers["MeterProvider"] is None
+    assert handlers["LoggerProvider"] is None
+
+
+# ---------------------------------------------------------------------------
+# (b) Default shutdown_on_exit=True -> atexit registered for all 3 providers
+# ---------------------------------------------------------------------------
+def test_default_shutdown_on_exit_registers_all_three_providers():
+    from anaconda_opentelemetry.signals import initialize_telemetry
+
+    initialize_telemetry(
+        config=_make_config(),
+        attributes=_make_attributes(),
+        signal_types=["logging", "metrics", "tracing"],
+        # default: shutdown_on_exit=True
+    )
+
+    handlers = _provider_atexit_handlers()
+    assert handlers["TracerProvider"] is not None, "TracerProvider atexit handler not set"
+    assert handlers["MeterProvider"] is not None, "MeterProvider atexit handler not set"
+    assert handlers["LoggerProvider"] is not None, "LoggerProvider atexit handler not set"
+
+
+# ---------------------------------------------------------------------------
+# (c) Global LoggerProvider retrievable via the OTel global getter after init
+# ---------------------------------------------------------------------------
+def test_global_logger_provider_retrievable_after_init():
+    from anaconda_opentelemetry.signals import initialize_telemetry
+    from opentelemetry import _logs
+    from opentelemetry.sdk._logs import LoggerProvider
+
+    # shutdown_on_exit=False to avoid registering atexit handlers from this test
+    initialize_telemetry(
+        config=_make_config(),
+        attributes=_make_attributes(),
+        signal_types=["logging", "metrics", "tracing"],
+        shutdown_on_exit=False,
+    )
+
+    lp = _logs.get_logger_provider()
+    # OTel's global setter is one-shot per process: even if a prior test set
+    # the global, the type contract (it's an SDK LoggerProvider) still holds.
+    assert isinstance(lp, LoggerProvider)
+
+
+def test_shutdown_telemetry_bounded_and_retryable_under_hanging_flush(monkeypatch):
+    import anaconda_opentelemetry.signals as sig
+
+    sig.__ANACONDA_TELEMETRY_INITIALIZED = True
+    sig._SHUTDOWN_DONE = False
+
+    attempts = []
+
+    def first_attempt_hangs():
+        attempts.append(1)
+        if len(attempts) == 1:
+            time.sleep(60)
+        return True
+
+    monkeypatch.setattr(sig, "flush_telemetry", first_attempt_hangs)
+
+    timeout = 0.3
+    start = time.monotonic()
+    first = sig.shutdown_telemetry(timeout_seconds=timeout)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0, f"exceeded bound: {elapsed:.3f}s (timeout={timeout}s)"
+    assert first is False
+    assert sig._SHUTDOWN_DONE is False
+
+    assert sig.shutdown_telemetry(timeout_seconds=1.0) is True
+    assert sig._SHUTDOWN_DONE is True
+
+
+# ---------------------------------------------------------------------------
+# (e) Idempotency: subsequent shutdown_telemetry calls are immediate no-ops
+# ---------------------------------------------------------------------------
+def test_shutdown_telemetry_is_idempotent(monkeypatch):
+    import anaconda_opentelemetry.signals as sig
+
+    sig.__ANACONDA_TELEMETRY_INITIALIZED = True
+    sig._SHUTDOWN_DONE = False
+
+    flush_calls = []
+
+    def counting_flush():
+        flush_calls.append(1)
+        return True
+
+    monkeypatch.setattr(sig, "flush_telemetry", counting_flush)
+
+    # First call performs the flush
+    r1 = sig.shutdown_telemetry()
+    assert r1 is True
+    assert len(flush_calls) == 1
+
+    # Second call must be a no-op returning True without re-flushing
+    r2 = sig.shutdown_telemetry()
+    assert r2 is True
+    assert len(flush_calls) == 1, (
+        "shutdown_telemetry must not invoke flush_telemetry on repeat calls"
+    )
+
+    # And still a no-op if a timeout is supplied
+    r3 = sig.shutdown_telemetry(timeout_seconds=0.1)
+    assert r3 is True
+    assert len(flush_calls) == 1
+
+
+def test_shutdown_telemetry_skips_when_already_in_progress(monkeypatch):
+    import anaconda_opentelemetry.signals as sig
+
+    sig.__ANACONDA_TELEMETRY_INITIALIZED = True
+    sig._SHUTDOWN_DONE = False
+
+    flush_calls = []
+
+    def counting_flush():
+        flush_calls.append(1)
+        return True
+
+    monkeypatch.setattr(sig, "flush_telemetry", counting_flush)
+
+    sig._shutdown_lock.acquire()
+    try:
+        assert sig.shutdown_telemetry() is False
+        assert flush_calls == []
+    finally:
+        sig._shutdown_lock.release()
+
+
+# ---------------------------------------------------------------------------
+# (f) Uninitialized: flush_telemetry / shutdown_telemetry return False
+# ---------------------------------------------------------------------------
+def test_flush_and_shutdown_return_false_when_uninitialized():
+    """Without initialize_telemetry(), the public APIs must short-circuit."""
+    import anaconda_opentelemetry.signals as sig
+
+    # Fixture has already reset __ANACONDA_TELEMETRY_INITIALIZED to False.
+    assert sig.__ANACONDA_TELEMETRY_INITIALIZED is False
+
+    assert sig.flush_telemetry() is False
+    assert sig.shutdown_telemetry() is False
+    assert sig.shutdown_telemetry(timeout_seconds=0.1) is False
+
+
+# ---------------------------------------------------------------------------
+# (g) flush_telemetry calls force_flush on tracer, meter, AND logger providers
+# ---------------------------------------------------------------------------
+def test_flush_telemetry_invokes_force_flush_on_all_three_providers():
+    import anaconda_opentelemetry.signals as sig
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk._logs import LoggerProvider
+
+    sig.__ANACONDA_TELEMETRY_INITIALIZED = True
+
+    # spec=ClassName makes isinstance(mock, ClassName) return True, which
+    # is required because flush_telemetry guards each call with isinstance.
+    mock_tp = MagicMock(spec=TracerProvider)
+    mock_tp.force_flush.return_value = True
+    mock_mp = MagicMock(spec=MeterProvider)
+    mock_mp.force_flush.return_value = True
+    mock_lp = MagicMock(spec=LoggerProvider)
+    mock_lp.force_flush.return_value = True
+
+    with patch(
+        "opentelemetry.trace.get_tracer_provider", return_value=mock_tp
+    ), patch(
+        "opentelemetry.metrics.get_meter_provider", return_value=mock_mp
+    ), patch(
+        "opentelemetry._logs.get_logger_provider", return_value=mock_lp
+    ):
+        result = sig.flush_telemetry()
+
+    mock_tp.force_flush.assert_called()
+    mock_mp.force_flush.assert_called()
+    mock_lp.force_flush.assert_called()
+    assert result is True
+
+
+def test_flush_telemetry_returns_false_when_a_provider_force_flush_raises():
+    """Failure on any single provider should be reflected in the return
+    value, and the other providers should still be flushed."""
+    import anaconda_opentelemetry.signals as sig
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk._logs import LoggerProvider
+
+    sig.__ANACONDA_TELEMETRY_INITIALIZED = True
+
+    mock_tp = MagicMock(spec=TracerProvider)
+    mock_tp.force_flush.return_value = True
+    mock_mp = MagicMock(spec=MeterProvider)
+    mock_mp.force_flush.side_effect = RuntimeError("boom")
+    mock_lp = MagicMock(spec=LoggerProvider)
+    mock_lp.force_flush.return_value = True
+
+    with patch(
+        "opentelemetry.trace.get_tracer_provider", return_value=mock_tp
+    ), patch(
+        "opentelemetry.metrics.get_meter_provider", return_value=mock_mp
+    ), patch(
+        "opentelemetry._logs.get_logger_provider", return_value=mock_lp
+    ):
+        result = sig.flush_telemetry()
+
+    # Each provider's force_flush is still attempted independently.
+    mock_tp.force_flush.assert_called()
+    mock_mp.force_flush.assert_called()
+    mock_lp.force_flush.assert_called()
+    assert result is False

--- a/tests/unit_tests/test_external.py
+++ b/tests/unit_tests/test_external.py
@@ -56,9 +56,9 @@ class TestInitializeTelemetry:
             mock.assert_called_once()
 
         # Verify all three metric types were initialized by default
-        mock_logger.assert_called_once_with(unittest.mock.ANY, unittest.mock.ANY)
-        mock_metrics.assert_called_once_with(unittest.mock.ANY, unittest.mock.ANY)
-        mock_trace.assert_called_once_with(unittest.mock.ANY, unittest.mock.ANY)
+        mock_logger.assert_called_once_with(unittest.mock.ANY, unittest.mock.ANY, shutdown_on_exit=True)
+        mock_metrics.assert_called_once_with(unittest.mock.ANY, unittest.mock.ANY, shutdown_on_exit=True)
+        mock_trace.assert_called_once_with(unittest.mock.ANY, unittest.mock.ANY, shutdown_on_exit=True)
 
         # Verify that _instance attributes were set on the mock classes
         assert hasattr(mock_logger, '_instance')

--- a/tests/unit_tests/test_external.py
+++ b/tests/unit_tests/test_external.py
@@ -56,9 +56,9 @@ class TestInitializeTelemetry:
             mock.assert_called_once()
 
         # Verify all three metric types were initialized by default
-        mock_logger.assert_called_once_with(unittest.mock.ANY, unittest.mock.ANY, shutdown_on_exit=True)
-        mock_metrics.assert_called_once_with(unittest.mock.ANY, unittest.mock.ANY, shutdown_on_exit=True)
-        mock_trace.assert_called_once_with(unittest.mock.ANY, unittest.mock.ANY, shutdown_on_exit=True)
+        mock_logger.assert_called_once_with(unittest.mock.ANY, unittest.mock.ANY)
+        mock_metrics.assert_called_once_with(unittest.mock.ANY, unittest.mock.ANY)
+        mock_trace.assert_called_once_with(unittest.mock.ANY, unittest.mock.ANY)
 
         # Verify that _instance attributes were set on the mock classes
         assert hasattr(mock_logger, '_instance')


### PR DESCRIPTION
Allow consumers to manage the the shutdown lifecycle. This fixes an indefinite hang bug when the consumer is a long-running process

- Allows consumers to specify `shutdown_on_exit`, defaulted to `True` to preserve existing behavior
- Adds `flush_telemetry` and `shutdown_telemetry` functions for consumers to use when they provide `shutdown_on_exit=False`